### PR TITLE
Feature/reduce memory usage 01

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ vet:
 test:
 	go test -cover -v -race ./...
 
+bench:
+	go test -bench . -benchmem -gcflags="-m -l" ./...
+
 dep-init:
 	dep ensure
 
@@ -27,4 +30,4 @@ example: dist/server_demo
 dist/server_demo:
 	go build -i -v -o $@ ./example/server_demo/...
 
-.PHONY: all pre fmt lint vet test dep-init dep-update example dist/server_demo
+.PHONY: all pre fmt lint vet test bench dep-init dep-update example dist/server_demo


### PR DESCRIPTION
Before:
```
> make bench
...
pkg: github.com/yutopp/go-rtmp/message
BenchmarkDecodeVideoMessage-4           10000000               133 ns/op             144 B/op          2 allocs/op
PASS
```

After:
```
> make bench
...
pkg: github.com/yutopp/go-rtmp/message
BenchmarkDecodeVideoMessage-4   	20000000	        70.3 ns/op	      32 B/op	       1 allocs/op
PASS
```