### PR TITLE
Reduce memory allocations

### DIFF
--- a/data_stream_handler_test.go
+++ b/data_stream_handler_test.go
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2018- yutopp (yutopp@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at  https://www.boost.org/LICENSE_1_0.txt)
+//
+
+package rtmp
+
+import (
+	"github.com/sirupsen/logrus"
+	"testing"
+
+	"github.com/yutopp/go-rtmp/message"
+)
+
+func BenchmarkHandlePublisherVideoMessage(b *testing.B) {
+	h := &dataStreamHandler{
+		state:   dataStreamStateHasPublisher,
+		handler: &DefaultHandler{},
+		logger:  logrus.StandardLogger(),
+	}
+
+	chunkStreamID := 0
+	timestamp := uint32(0)
+	msg := &message.VideoMessage{}
+	stream := &Stream{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.Handle(chunkStreamID, timestamp, msg, stream)
+	}
+}


### PR DESCRIPTION
Before
```
pkg: github.com/yutopp/go-rtmp
BenchmarkHandlePublisherVideoMessage-4   	 2000000	       680 ns/op	     752 B/op	       5 allocs/op
PASS
```

After
```
pkg: github.com/yutopp/go-rtmp
BenchmarkHandlePublisherVideoMessage-4   	30000000	        39.7 ns/op	       0 B/op	       0 allocs/op
PASS
```