### PR TITLE
[proposal] add playback support

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -9,6 +9,7 @@ package rtmp
 
 import (
 	"bufio"
+	"context"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -129,6 +130,10 @@ func (c *Conn) Close() error {
 	}
 
 	return result
+}
+
+func (c *Conn) Write(ctx context.Context, chunkStreamID int, timestamp uint32, cmsg *ChunkMessage) error {
+	return c.streamer.Write(ctx, chunkStreamID, timestamp, cmsg)
 }
 
 func (c *Conn) handleMessageLoop() (err error) {

--- a/message/body_decoder.go
+++ b/message/body_decoder.go
@@ -222,7 +222,15 @@ func DecodeBodyPlay(_ io.Reader, d AMFDecoder, v *AMFConvertible) error {
 	}
 	var start int64
 	if err := d.Decode(&start); err != nil {
-		return errors.Wrap(err, "Failed to decode 'play' args[2]")
+		//
+		// io.EOF occurs when the start position is not specified.
+		//  'NetStream.play(streamName,null)'
+		// set start to 0 to avoid it.
+		//
+		if err != io.EOF {
+			return errors.Wrap(err, "Failed to decode 'play' args[2]")
+		}
+		start = 0
 	}
 
 	var cmd NetStreamPlay


### PR DESCRIPTION
I want to be able to implement playback using the `OnPlay` method.
seems achieve it by adding `Conn.Write`.
for example, playback can be implemented as below:

```
var _ rtmp.Handler = (*Handler)(nil)

type Handler struct {
    rtmp.DefaultHandler
    conn *rtmp.Conn
}
func (h *Handler) writeVideo(timestamp uint32, videoTag *tag.VideoData) error {
    buf := &bytes.Buffer{}
	if err := tag.EncodeVideoData(buf, videoTag); err != nil {
        return err
    }
    ctx := context.TODO() // TODO
    h.conn.Write(ctx, 2, timestamp, &rtmp.ChunkMessage{
        StreamID: 0,
        Message:  &message.VideoMessage{
            Payload: bytes.NewReader(buf.Bytes())
        },
    })
}
func (h *Handler) WriteIDR(data []byte, timestamp uint32, compositionTime int32) error {
    isombcc := avc.CreateISOBMFF(data)
    
    return h.writeVideo(timestamp, &tag.VideoData{
        FrameType:       tag.FrameType(tag.FrameTypeInterFrame),
        AVCPacketType:   tag.AVCPacketType(tag.AVCPacketTypeNALU),
        CompositionTime: compositionTime,
        CodecID:         tag.CodecIDAVC,
        Data:            bytes.NewReader(isobmff.Bytes()),
    })
}
func (h *Handler) WriteAVCDCR(sps, pps []byte) error {
    avcdcr := avc.CreateAVCDecoderConfigurationRecord(sps, pps)
    
    return h.writeVideo(0, &tag.VideoData{
        FrameType:       tag.FrameType(tag.FrameTypeKeyFrame),
        AVCPacketType:   tag.AVCPacketType(tag.AVCPacketTypeSequenceHeader),
        CompositionTime: 0,
        CodecID:         tag.CodecIDAVC,
        Data:            bytes.NewReader(avcdcr),
    }) 
}
func (h *Handler) OnServe(conn *rtmp.Conn) {
    h.conn = conn
}
func (h *Handler) OnPlay(timestamp uint32, cmd *message.NetStreamPlay) error {
    // load mystream
    mystream := NewMyStream(cmd.StreamName)
    go func(){
        for {
            select {
            case data := <-mystream.AVC.SeqHead():
                h.WriteAVCDCR(data.SPS, data.PPS)
            case data := mystream.AVC.IDR():
                h.WriteIDR(data.Data, data.Timestamp, data.CTime)
            :
            : other channels
            :
            }
        }
    }()
}
```

Here is a screenshot of playback on ffplay using this implementation.

![screenshot](https://user-images.githubusercontent.com/42143893/70707671-05187480-1d1c-11ea-97c2-0a107949f95d.png)

and, some clients don't seem to specify a start position. added workaround code to avoid `io.EOF`.