### PR TITLE
Add operations relevant for push

### DIFF
--- a/client_conn.go
+++ b/client_conn.go
@@ -81,7 +81,7 @@ func (cc *ClientConn) Connect(body *message.NetConnectionConnect) error {
 	return nil
 }
 
-func (cc *ClientConn) CreateStream(body *message.NetConnectionCreateStream) (*Stream, error) {
+func (cc *ClientConn) CreateStream(body *message.NetConnectionCreateStream, chunkSize uint32) (*Stream, error) {
 	if err := cc.controllable(); err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (cc *ClientConn) CreateStream(body *message.NetConnectionCreateStream) (*St
 		return nil, err
 	}
 
-	result, err := stream.CreateStream(body)
+	result, err := stream.CreateStream(body, chunkSize)
 	if err != nil {
 		return nil, err // TODO: wrap an error
 	}

--- a/client_conn.go
+++ b/client_conn.go
@@ -81,7 +81,7 @@ func (cc *ClientConn) Connect(body *message.NetConnectionConnect) error {
 	return nil
 }
 
-func (cc *ClientConn) CreateStream(body *message.NetConnectionConnect) (*Stream, error) {
+func (cc *ClientConn) CreateStream(body *message.NetConnectionCreateStream) (*Stream, error) {
 	if err := cc.controllable(); err != nil {
 		return nil, err
 	}

--- a/client_conn.go
+++ b/client_conn.go
@@ -39,7 +39,7 @@ func newClientConnWithSetup(c net.Conn, config *ConnConfig) (*ClientConn, error)
 	}
 	ctrlStream.handler.ChangeState(streamStateClientNotConnected)
 
-	conn.streamer.controlStreamWriter = ctrlStream.write
+	conn.streamer.controlStreamWriter = ctrlStream.Write
 
 	cc := &ClientConn{
 		conn: conn,

--- a/example/client_demo/main.go
+++ b/example/client_demo/main.go
@@ -7,6 +7,10 @@ import (
 	rtmpmsg "github.com/yutopp/go-rtmp/message"
 )
 
+const (
+	chunkSize = 128
+)
+
 func main() {
 	client, err := rtmp.Dial("rtmp", "localhost:1935", &rtmp.ConnConfig{
 		Logger: log.StandardLogger(),
@@ -22,7 +26,7 @@ func main() {
 	}
 	log.Infof("connected")
 
-	stream, err := client.CreateStream(nil)
+	stream, err := client.CreateStream(nil, 128)
 	if err != nil {
 		log.Fatalf("Failed to create stream: Err=%+v", err)
 	}

--- a/example/client_demo/main.go
+++ b/example/client_demo/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 	log.Infof("connected")
 
-	stream, err := client.CreateStream(nil, 128)
+	stream, err := client.CreateStream(nil, chunkSize)
 	if err != nil {
 		log.Fatalf("Failed to create stream: Err=%+v", err)
 	}

--- a/message/net_connection.go
+++ b/message/net_connection.go
@@ -105,7 +105,9 @@ func (t *NetConnectionCreateStream) FromArgs(args ...interface{}) error {
 }
 
 func (t *NetConnectionCreateStream) ToArgs(ty EncodingType) ([]interface{}, error) {
-	panic("Not implemented")
+	return []interface{}{
+		nil, // Just null
+	}, nil
 }
 
 // TODO: fix for error messages

--- a/message/net_stream.go
+++ b/message/net_stream.go
@@ -152,6 +152,24 @@ func (t *NetStreamFCUnpublish) ToArgs(ty EncodingType) ([]interface{}, error) {
 	}, nil
 }
 
+type NetStreamReleaseStream struct {
+	StreamName string
+}
+
+func (t *NetStreamReleaseStream) FromArgs(args ...interface{}) error {
+	// args[0] is unknown, ignore
+	t.StreamName = args[1].(string)
+
+	return nil
+}
+
+func (t *NetStreamReleaseStream) ToArgs(ty EncodingType) ([]interface{}, error) {
+	return []interface{}{
+		nil, // no command object
+		t.StreamName,
+	}, nil
+}
+
 // NetStreamSetDataFrame - send data. AmfData is what will be encoded
 type NetStreamSetDataFrame struct {
 	Payload []byte

--- a/message/net_stream.go
+++ b/message/net_stream.go
@@ -152,19 +152,22 @@ func (t *NetStreamFCUnpublish) ToArgs(ty EncodingType) ([]interface{}, error) {
 	}, nil
 }
 
-//
+// NetStreamSetDataFrame - send data. AmfData is what will be encoded
 type NetStreamSetDataFrame struct {
 	Payload []byte
+	AmfData interface{}
 }
 
 func (t *NetStreamSetDataFrame) FromArgs(args ...interface{}) error {
 	t.Payload = args[0].([]byte)
-
 	return nil
 }
 
 func (t *NetStreamSetDataFrame) ToArgs(ty EncodingType) ([]interface{}, error) {
-	panic("Not implemented")
+	return []interface{}{
+		"onMetaData",
+		t.AmfData,
+	}, nil
 }
 
 //

--- a/message/net_stream_test.go
+++ b/message/net_stream_test.go
@@ -43,6 +43,14 @@ var netStreamTestCases = []netStreamTestCase{
 			StreamName: "theStream",
 		},
 	},
+	netStreamTestCase{
+		Name: "NetStreamFCPublish OK",
+		Box:  &NetStreamFCPublish{},
+		Args: []interface{}{nil, "theStream"}, // First argument is unknown
+		ExpectedMsg: &NetStreamFCPublish{
+			StreamName: "theStream",
+		},
+	},
 }
 
 func TestConvertNetStreamMessages(t *testing.T) {

--- a/message/net_stream_test.go
+++ b/message/net_stream_test.go
@@ -35,6 +35,14 @@ var netStreamTestCases = []netStreamTestCase{
 			PublishingType: "bbb",
 		},
 	},
+	netStreamTestCase{
+		Name: "NetStreamReleaseStream OK",
+		Box:  &NetStreamReleaseStream{},
+		Args: []interface{}{nil, "theStream"}, // First argument is unknown
+		ExpectedMsg: &NetStreamReleaseStream{
+			StreamName: "theStream",
+		},
+	},
 }
 
 func TestConvertNetStreamMessages(t *testing.T) {

--- a/server_client_test.go
+++ b/server_client_test.go
@@ -88,12 +88,12 @@ func TestServerCanAcceptCreateStream(t *testing.T) {
 		err := c.Connect(nil)
 		assert.Nil(t, err)
 
-		s0, err := c.CreateStream(nil, 128)
+		s0, err := c.CreateStream(nil, chunkSize)
 		assert.Nil(t, err)
 		defer s0.Close()
 
 		// Rejected because a number of message streams is exceeded the limits
-		s1, err := c.CreateStream(nil, 128)
+		s1, err := c.CreateStream(nil, chunkSize)
 		assert.Equal(t, &CreateStreamRejectedError{
 			TransactionID: 2,
 			Result: &message.NetConnectionCreateStreamResult{

--- a/server_client_test.go
+++ b/server_client_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/yutopp/go-rtmp/message"
 )
 
+const (
+	chunkSize = 128
+)
+
 func TestServerCanAcceptConnect(t *testing.T) {
 	config := &ConnConfig{
 		Handler: &ServerCanAcceptConnectHandler{},
@@ -84,12 +88,12 @@ func TestServerCanAcceptCreateStream(t *testing.T) {
 		err := c.Connect(nil)
 		assert.Nil(t, err)
 
-		s0, err := c.CreateStream(nil)
+		s0, err := c.CreateStream(nil, 128)
 		assert.Nil(t, err)
 		defer s0.Close()
 
 		// Rejected because a number of message streams is exceeded the limits
-		s1, err := c.CreateStream(nil)
+		s1, err := c.CreateStream(nil, 128)
 		assert.Equal(t, &CreateStreamRejectedError{
 			TransactionID: 2,
 			Result: &message.NetConnectionCreateStreamResult{

--- a/server_conn.go
+++ b/server_conn.go
@@ -37,7 +37,7 @@ func (sc *serverConn) Serve() error {
 	}
 	ctrlStream.handler.ChangeState(streamStateServerNotConnected)
 
-	sc.conn.streamer.controlStreamWriter = ctrlStream.write
+	sc.conn.streamer.controlStreamWriter = ctrlStream.Write
 
 	if sc.conn.handler != nil {
 		sc.conn.handler.OnServe(sc.conn)

--- a/stream.go
+++ b/stream.go
@@ -257,6 +257,25 @@ func (s *Stream) writeCommandMessage(
 	})
 }
 
+func (s *Stream) WriteDataMessage(
+	chunkStreamID int,
+	timestamp uint32,
+	name string,
+	body message.AMFConvertible,
+) error {
+	buf := new(bytes.Buffer)
+	amfEnc := message.NewAMFEncoder(buf, message.EncodingTypeAMF0)
+	if err := message.EncodeBodyAnyValues(amfEnc, body); err != nil {
+		return err
+	}
+
+	return s.write(chunkStreamID, timestamp, &message.DataMessage{
+		Name:     name,
+		Encoding: message.EncodingTypeAMF0,
+		Body:     buf,
+	})
+}
+
 func (s *Stream) write(chunkStreamID int, timestamp uint32, msg message.Message) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TODO: Fix 5s
 	defer cancel()

--- a/stream.go
+++ b/stream.go
@@ -46,15 +46,15 @@ func newStream(streamID uint32, conn *Conn) *Stream {
 }
 
 func (s *Stream) WriteWinAckSize(chunkStreamID int, timestamp uint32, msg *message.WinAckSize) error {
-	return s.write(chunkStreamID, timestamp, msg)
+	return s.Write(chunkStreamID, timestamp, msg)
 }
 
 func (s *Stream) WriteSetPeerBandwidth(chunkStreamID int, timestamp uint32, msg *message.SetPeerBandwidth) error {
-	return s.write(chunkStreamID, timestamp, msg)
+	return s.Write(chunkStreamID, timestamp, msg)
 }
 
 func (s *Stream) WriteUserCtrl(chunkStreamID int, timestamp uint32, msg *message.UserCtrl) error {
-	return s.write(chunkStreamID, timestamp, msg)
+	return s.Write(chunkStreamID, timestamp, msg)
 }
 
 func (s *Stream) Connect(
@@ -249,7 +249,7 @@ func (s *Stream) writeCommandMessage(
 		return err
 	}
 
-	return s.write(chunkStreamID, timestamp, &message.CommandMessage{
+	return s.Write(chunkStreamID, timestamp, &message.CommandMessage{
 		CommandName:   commandName,
 		TransactionID: transactionID,
 		Encoding:      s.encTy,
@@ -269,14 +269,14 @@ func (s *Stream) WriteDataMessage(
 		return err
 	}
 
-	return s.write(chunkStreamID, timestamp, &message.DataMessage{
+	return s.Write(chunkStreamID, timestamp, &message.DataMessage{
 		Name:     name,
 		Encoding: message.EncodingTypeAMF0,
 		Body:     buf,
 	})
 }
 
-func (s *Stream) write(chunkStreamID int, timestamp uint32, msg message.Message) error {
+func (s *Stream) Write(chunkStreamID int, timestamp uint32, msg message.Message) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TODO: Fix 5s
 	defer cancel()
 

--- a/stream.go
+++ b/stream.go
@@ -130,7 +130,7 @@ func (s *Stream) ReplyConnect(
 }
 
 func (s *Stream) CreateStream(
-	body *message.NetConnectionConnect,
+	body *message.NetConnectionCreateStream,
 ) (*message.NetConnectionCreateStreamResult, error) {
 	transactionID := int64(2) // TODO: fix
 	t, err := s.transactions.Create(transactionID)
@@ -139,7 +139,7 @@ func (s *Stream) CreateStream(
 	}
 
 	if body == nil {
-		body = &message.NetConnectionConnect{}
+		body = &message.NetConnectionCreateStream{}
 	}
 
 	chunkStreamID := 3 // TODO: fix


### PR DESCRIPTION
When implementing a client to be able to push RTMP towards twitch and Youtube I found that some methods were marked as "Not implemented" or missing, so I've added them.

Two of them change the API a little:

- Stream.Write becomes public
- Stream.CreateStream and ClientConn.CreateStream get a new parameter to set the chunkSize

Setting the chunk size is of course not really needed, but is nice both from an efficiency point of view and making network captures easier to debug.

It would be nice if these extensions could be included in this repo, since I think that they are generally useful.
