### PR TITLE
Fix bug writing same timestamp with different messageid.

### DIFF
--- a/chunk_stream_writer.go
+++ b/chunk_stream_writer.go
@@ -15,10 +15,11 @@ import (
 type ChunkStreamWriter struct {
 	ChunkStreamReader
 
-	doneCh  chan struct{}
-	closeCh chan struct{}
-	lastErr error
-	aqM     sync.Mutex
+	doneCh   chan struct{}
+	closeCh  chan struct{}
+	lastErr  error
+	aqM      sync.Mutex
+	newChunk bool
 }
 
 func (w *ChunkStreamWriter) Write(b []byte) (int, error) {

--- a/chunk_streamer.go
+++ b/chunk_streamer.go
@@ -130,7 +130,6 @@ func (cs *ChunkStreamer) Write(
 	writer.messageLength = uint32(writer.buf.Len())
 	writer.messageTypeID = byte(cmsg.Message.TypeID())
 	writer.messageStreamID = cmsg.StreamID
-	writer.newChunk = true
 
 	return cs.Sched(writer)
 }
@@ -169,6 +168,7 @@ func (cs *ChunkStreamer) NewChunkWriter(ctx context.Context, chunkStreamID int) 
 }
 
 func (cs *ChunkStreamer) Sched(writer *ChunkStreamWriter) error {
+	writer.newChunk = true
 	return cs.writerSched.Sched(writer)
 }
 

--- a/chunk_streamer.go
+++ b/chunk_streamer.go
@@ -130,6 +130,7 @@ func (cs *ChunkStreamer) Write(
 	writer.messageLength = uint32(writer.buf.Len())
 	writer.messageTypeID = byte(cmsg.Message.TypeID())
 	writer.messageStreamID = cmsg.StreamID
+	writer.newChunk = true
 
 	return cs.Sched(writer)
 }
@@ -305,13 +306,14 @@ func (cs *ChunkStreamer) writeChunk(writer *ChunkStreamWriter) (bool, error) {
 
 func (cs *ChunkStreamer) updateWriterHeader(writer *ChunkStreamWriter) {
 	fmt := byte(2) // default: only timestamp delta
-	if writer.messageHeader.messageLength != writer.messageLength || writer.messageTypeID != writer.messageHeader.messageTypeID {
+	if writer.messageHeader.messageLength != writer.messageLength ||
+		writer.messageTypeID != writer.messageHeader.messageTypeID {
 		// header or type id is updated, change fmt to 1 to notify difference and update state
 		writer.messageHeader.messageLength = writer.messageLength
 		writer.messageHeader.messageTypeID = writer.messageTypeID
 		fmt = 1
 	}
-	if writer.timestamp != writer.messageHeader.timestamp {
+	if writer.timestamp != writer.messageHeader.timestamp || writer.newChunk {
 		if writer.timestamp >= writer.messageHeader.timestamp {
 			writer.timestampDelta = writer.timestamp - writer.messageHeader.timestamp
 		} else {
@@ -320,6 +322,7 @@ func (cs *ChunkStreamer) updateWriterHeader(writer *ChunkStreamWriter) {
 			writer.timestampDelta = 0
 		}
 	}
+	writer.newChunk = false
 	if writer.timestampDelta == writer.messageHeader.timestampDelta && fmt == 2 {
 		fmt = 3
 	}
@@ -409,8 +412,9 @@ func (cs *ChunkStreamer) prepareChunkWriter(chunkStreamID int) (*ChunkStreamWrit
 					timestamp: math.MaxUint32, // initial state will be updated by writer.timestamp
 				},
 			},
-			doneCh:  make(chan struct{}),
-			closeCh: make(chan struct{}),
+			doneCh:   make(chan struct{}),
+			closeCh:  make(chan struct{}),
+			newChunk: true,
 		}
 		close(writer.doneCh)
 		cs.writers[chunkStreamID] = writer


### PR DESCRIPTION
See following case.

```bash
2022/09/28 15:02:25 FLV Audio Data: Timestamp = 490, SoundFormat = 10, SoundRate = 3, SoundSize = 1, SoundType = 1, AACPacketType = 1, Data length = 427
2022/09/28 15:02:25 FLV Video Data: Timestamp = 500, FrameType = 2, CodecID = 7, AVCPacketType = 1, CT = 0, Data length = 1799
2022/09/28 15:02:25 FLV Audio Data: Timestamp = 512, SoundFormat = 10, SoundRate = 3, SoundSize = 1, SoundType = 1, AACPacketType = 1, Data length = 426
2022/09/28 15:02:25 FLV Video Data: Timestamp = 533, FrameType = 2, CodecID = 7, AVCPacketType = 1, CT = 0, Data length = 1706
2022/09/28 15:02:25 FLV Audio Data: Timestamp = 533, SoundFormat = 10, SoundRate = 3, SoundSize = 1, SoundType = 1, AACPacketType = 1, Data length = 427
2022/09/28 15:02:25 FLV Audio Data: Timestamp = 554, SoundFormat = 10, SoundRate = 3, SoundSize = 1, SoundType = 1, AACPacketType = 1, Data length = 427
```

In rtmp protocol, It is possible that write same timestamp with different messageid(video, audio).

Currently there is a bug in go-rtmp's writers. 

I think writer should use newChunk before writing. 