### PR TITLE
Implement deleteStream command on client connection

### DIFF
--- a/client_conn.go
+++ b/client_conn.go
@@ -106,6 +106,30 @@ func (cc *ClientConn) CreateStream(body *message.NetConnectionCreateStream, chun
 	return newStream, nil
 }
 
+func (cc *ClientConn) DeleteStream(body *message.NetStreamDeleteStream) error {
+	if err := cc.controllable(); err != nil {
+		return err
+	}
+
+	ctrlStream, err := cc.conn.streams.At(ControlStreamID)
+	if err != nil {
+		return err
+	}
+
+	// Check if stream id exists
+	_, err = cc.conn.streams.At(body.StreamID)
+	if err != nil {
+		return err
+	}
+
+	err = ctrlStream.DeleteStream(body)
+	if err != nil {
+		return err
+	}
+
+	return cc.conn.streams.Delete(body.StreamID)
+}
+
 func (cc *ClientConn) startHandleMessageLoop() {
 	if err := cc.conn.handleMessageLoop(); err != nil {
 		cc.setLastError(err)

--- a/client_conn.go
+++ b/client_conn.go
@@ -30,11 +30,13 @@ func newClientConnWithSetup(c net.Conn, config *ConnConfig) (*ClientConn, error)
 	if err := handshake.HandshakeWithServer(conn.rwc, conn.rwc, &handshake.Config{
 		SkipHandshakeVerification: conn.config.SkipHandshakeVerification,
 	}); err != nil {
+		_ = conn.Close()
 		return nil, errors.Wrap(err, "Failed to handshake")
 	}
 
 	ctrlStream, err := conn.streams.Create(ControlStreamID)
 	if err != nil {
+		_ = conn.Close()
 		return nil, errors.Wrap(err, "Failed to create control stream")
 	}
 	ctrlStream.handler.ChangeState(streamStateClientNotConnected)

--- a/message/net_stream.go
+++ b/message/net_stream.go
@@ -107,7 +107,10 @@ func (t *NetStreamDeleteStream) FromArgs(args ...interface{}) error {
 }
 
 func (t *NetStreamDeleteStream) ToArgs(ty EncodingType) ([]interface{}, error) {
-	panic("Not implemented")
+	return []interface{}{
+		nil, // no command object
+		t.StreamID,
+	}, nil
 }
 
 type NetStreamFCPublish struct {

--- a/stream.go
+++ b/stream.go
@@ -45,6 +45,10 @@ func newStream(streamID uint32, conn *Conn) *Stream {
 	return s
 }
 
+func (s *Stream) StreamID() uint32 {
+	return s.streamID
+}
+
 func (s *Stream) WriteWinAckSize(chunkStreamID int, timestamp uint32, msg *message.WinAckSize) error {
 	return s.Write(chunkStreamID, timestamp, msg)
 }
@@ -187,6 +191,18 @@ func (s *Stream) CreateStream(body *message.NetConnectionCreateStream, chunkSize
 	}
 
 	//return nil, errors.New("Failed to get result")
+}
+
+func (s *Stream) DeleteStream(body *message.NetStreamDeleteStream) error {
+	chunkStreamID := 3 // TODO: fix
+
+	return s.writeCommandMessage(
+		chunkStreamID,
+		0,
+		"deleteStream",
+		0,
+		body,
+	)
 }
 
 func (s *Stream) ReplyCreateStream(


### PR DESCRIPTION
Hello, I implemented the possibility to send a deleteStream command on a client connection. The aim is to properly end a stream. I am not sure it is the best way to do it so I am open to your feedbacks.