### PR TITLE
Fix decoding of publish command, publishing type is optional

### DIFF
--- a/message/body_decoder.go
+++ b/message/body_decoder.go
@@ -200,7 +200,12 @@ func DecodeBodyPublish(_ io.Reader, d AMFDecoder, v *AMFConvertible) error {
 	}
 	var publishingType string
 	if err := d.Decode(&publishingType); err != nil {
-		return errors.Wrap(err, "Failed to decode 'publish' args[2]")
+		// value is optional
+		if errors.Is(err, io.EOF) {
+			publishingType = "live"
+		} else {
+			return errors.Wrap(err, "Failed to decode 'publish' args[2]")
+		}
 	}
 
 	var cmd NetStreamPublish

--- a/message/body_decoder_test.go
+++ b/message/body_decoder_test.go
@@ -112,6 +112,25 @@ func TestDecodeCmdMessagePublish(t *testing.T) {
 	}, v)
 }
 
+func TestDecodeCmdMessagePublishWithoutPublishingType(t *testing.T) {
+	bin := []byte{
+		// nil
+		0x05,
+		// string: abc
+		0x02, 0x00, 0x03, 0x61, 0x62, 0x63,
+	}
+	r := bytes.NewReader(bin)
+	d := amf0.NewDecoder(r)
+
+	var v AMFConvertible
+	err := CmdBodyDecoderFor("publish", 42)(r, d, &v)
+	require.Nil(t, err)
+	require.Equal(t, &NetStreamPublish{
+		PublishingName: "abc",
+		PublishingType: "live",
+	}, v)
+}
+
 func TestDecodeCmdMessagePlay(t *testing.T) {
 	bin := []byte{
 		// nil


### PR DESCRIPTION
I have noticed that some tools are not providing the publishing type in the publish command. It is not explicitly optional in the specification but in practice it seems to be. And so by default I use the `live` value