### PR TITLE
feat: Add get method for streamer

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -105,6 +105,10 @@ func newConn(rwc io.ReadWriteCloser, config *ConnConfig) *Conn {
 	return conn
 }
 
+func (c *Conn) GetChunkStreamer() *ChunkStreamer {
+	return c.streamer
+}
+
 func (c *Conn) Close() error {
 	c.m.Lock()
 	defer c.m.Unlock()


### PR DESCRIPTION
To retrieve RTMP stats, access to the streamer object is required.