### PR TITLE
Add missing "omitempty"

### DIFF
--- a/message/net_connection.go
+++ b/message/net_connection.go
@@ -26,16 +26,16 @@ type NetConnectionConnect struct {
 }
 
 type NetConnectionConnectCommand struct {
-	App            string       `mapstructure:"app" amf0:"app"`
-	Type           string       `mapstructure:"type" amf0:"type"`
-	FlashVer       string       `mapstructure:"flashVer" amf0:"flashVer"`
-	TCURL          string       `mapstructure:"tcUrl" amf0:"tcUrl"`
-	Fpad           bool         `mapstructure:"fpad" amf0:"fpad"`
-	Capabilities   int          `mapstructure:"capabilities" amf0:"capabilities"`
-	AudioCodecs    int          `mapstructure:"audioCodecs" amf0:"audioCodecs"`
-	VideoCodecs    int          `mapstructure:"videoCodecs" amf0:"videoCodecs"`
-	VideoFunction  int          `mapstructure:"videoFunction" amf0:"videoFunction"`
-	ObjectEncoding EncodingType `mapstructure:"objectEncoding" amf0:"objectEncoding"`
+	App            string       `mapstructure:"app,omitempty" amf0:"app"`
+	Type           string       `mapstructure:"type,omitempty" amf0:"type"`
+	FlashVer       string       `mapstructure:"flashVer,omitempty" amf0:"flashVer"`
+	TCURL          string       `mapstructure:"tcUrl,omitempty" amf0:"tcUrl"`
+	Fpad           bool         `mapstructure:"fpad,omitempty" amf0:"fpad"`
+	Capabilities   int          `mapstructure:"capabilities,omitempty" amf0:"capabilities"`
+	AudioCodecs    int          `mapstructure:"audioCodecs,omitempty" amf0:"audioCodecs"`
+	VideoCodecs    int          `mapstructure:"videoCodecs,omitempty" amf0:"videoCodecs"`
+	VideoFunction  int          `mapstructure:"videoFunction,omitempty" amf0:"videoFunction"`
+	ObjectEncoding EncodingType `mapstructure:"objectEncoding,omitempty" amf0:"objectEncoding"`
 }
 
 func (t *NetConnectionConnect) FromArgs(args ...interface{}) error {


### PR DESCRIPTION
Adding `omitempty` allows avoid sending the arguments to the RTMP server.


If I stream using ffmpeg, then I see:
```
20:06:04.219752 eth0  Out IP 192.168.0.131.45964 > 209.85.202.134.1935: Flags [P.], seq 3074:3236, ack 3074, win 249, options [nop,nop,TS val 1102617899 ecr 4170928345], length 162
E....F@.@........U......xV...^,/.....u.....
A..+..P................connect.?..........app...live2..type..
nonprivate..flashVer..#FMLE/3.0 (compatible; Lavf61.1.100)..tcUrl..$rtmp://a.rtmp.yout.ube.com:1935/live2..
20:06:04.224725 eth0  P   IP 209.85.202.134.1935 > 192.168.0.131.45964: Flags [.], ack 3236, win 311, options [nop,nop,TS val 4170928350 ecr 1102617899], length 0
E..4e...x..$.U...........^,/xV.e...7(......
..P.A..+
```

But if I stream using `go-rtmp` then I see:
```
20:41:25.147081 eth0  Out IP 192.168.0.131.48678 > 209.85.202.134.1935: Flags [P.], seq 3074:3214, ack 3074, win 249, options [nop,nop,TS val 1104738827 ecr 2545297054], length 140
E.....@.@.Z5.....U...&...P..........t .....
A.....&................connect.?..........app...live2..type..
nonprivate..flashVer...StreamPanel..tcUrl...rtmp://a.rtmp.youtube.com/live2..fpad....c
20:41:25.147106 home  Out IP 192.168.0.131.48678 > 209.85.202.134.1935: Flags [P.], seq 3214:3331, ack 3074, win 249, options [nop,nop,TS val 1104738827 ecr 2545297054], length 117
E.....@.@.ZK.....U...&...P.^........]......
A.....&..apabilities...........audioCodecs...........videoCodecs...........videoFunction...........objectEncoding...........
20:41:25.151849 eth0  P   IP 209.85.202.134.1935 > 192.168.0.131.48678: Flags [.], ack 1542, win 278, options [nop,nop,TS val 2545297059 ecr 1104738826], length 0
E..4R...x....U.........&.....P.......n.....
..&.A..
```

So all these empty fields are set. And I don't want to set `audioCodecs` to `0`.