### PR TITLE
Fixed parsing of extended timestamp in chunk message header type 3

### DIFF
--- a/chunk_stream_reader.go
+++ b/chunk_stream_reader.go
@@ -11,6 +11,14 @@ import (
 	"bytes"
 )
 
+type ExtendedTimestampMode byte
+
+const (
+	ExtendedTimestampUnused    ExtendedTimestampMode = 0
+	ExtendedTimestampUsed      ExtendedTimestampMode = 1
+	ExtendedTimestampDeltaUsed ExtendedTimestampMode = 2
+)
+
 type ChunkStreamReader struct {
 	basicHeader   chunkBasicHeader
 	messageHeader chunkMessageHeader
@@ -20,6 +28,8 @@ type ChunkStreamReader struct {
 	messageLength   uint32 // max, 24bits
 	messageTypeID   byte
 	messageStreamID uint32
+
+	extendedTimestampMode ExtendedTimestampMode
 
 	buf       bytes.Buffer
 	completed bool

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ package rtmp
 import (
 	"io"
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -116,6 +117,9 @@ func (srv *Server) handleConn(conn net.Conn) {
 	if err := sc.Serve(); err != nil {
 		if err == io.EOF {
 			c.logger.Infof("Server closed")
+			return
+		} else if strings.HasPrefix(err.Error(), "Failed to handshake") {
+			c.logger.Debugf("Server handshake failed")
 			return
 		}
 		c.logger.Errorf("Server closed by error: Err = %+v", err)


### PR DESCRIPTION
It appears that extended timestamps can be used in chunk message header type 3 if it was used in preceding non type 3 chunk. This is defined in RTMP specification in Extended Timestamp section:
```
This field is present in Type 3 chunks when the most recent Type 0,
1, or 2 chunk for the same chunk stream ID indicated the presence of
an extended timestamp field.
```

You can reproduce the problem using ffmpeg by adding a filter to modify the first PTS to a huge value forcing to use a high timestampDelta: `ffmpeg -re -i ${YOUR_INPUT_FILE} -vf "setpts=PTS+20000/TB" -af "asetpts=PTS+20000/TB" ... your encoding options... -f flv ${YOUR_RTMP_SERVER}`
This adds 20000 seconds to the first PTS which is greater than what a non-extended timestamp can support (at most 16777214 milliseconds)